### PR TITLE
Fix parse error in decompress

### DIFF
--- a/sample_code/src/fst_reference/block/vcdata.py
+++ b/sample_code/src/fst_reference/block/vcdata.py
@@ -133,20 +133,24 @@ def _parse_wave_data(wave_data: bytes, positions: list[int]) -> list[dict[str, A
             entry["offset"] = offset
             entry["uncompressed_length"] = uncompressed_length
             entry["compressed_length"] = compressed_length
-            ## TODO: only support lz4 compression for wave data now
-            data = br.read_bytes(compressed_length)
-            try:
-                dec_data = lz4.block.decompress(
-                    data, uncompressed_size=uncompressed_length
-                )
-                if len(dec_data) != uncompressed_length:
-                    raise RuntimeError(
-                        f"CallVCDATA: wave data uncompressed length mismatch for var {i}"
-                    )
-            except Exception as e:
-                entry["lz4_error"] = f"decompression error: {str(e)}"
+            if uncompressed_length == 0:
+                # The data is uncompressed
+                data = br.read_bytes(num_bytes - consumed)
             else:
-                entry["lz4_error"] = ""
+                ## TODO: only support lz4 compression for wave data now
+                data = br.read_bytes(compressed_length)
+                try:
+                    dec_data = lz4.block.decompress(
+                        data, uncompressed_size=uncompressed_length
+                    )
+                    if len(dec_data) != uncompressed_length:
+                        raise RuntimeError(
+                            f"CallVCDATA: wave data uncompressed length mismatch for var {i}"
+                        )
+                except Exception as e:
+                    entry["lz4_error"] = f"decompression error: {str(e)}"
+                else:
+                    entry["lz4_error"] = ""
         elif pos < 0:
             entry["type"] = "alias"
             entry["alias_of"] = -i - 1

--- a/sample_code/src/fst_reference/block/vcdata.py
+++ b/sample_code/src/fst_reference/block/vcdata.py
@@ -136,6 +136,7 @@ def _parse_wave_data(wave_data: bytes, positions: list[int]) -> list[dict[str, A
             if uncompressed_length == 0:
                 # The data is uncompressed
                 data = br.read_bytes(num_bytes - consumed)
+                entry["bin"] = data.hex()
             else:
                 ## TODO: only support lz4 compression for wave data now
                 data = br.read_bytes(compressed_length)
@@ -147,6 +148,7 @@ def _parse_wave_data(wave_data: bytes, positions: list[int]) -> list[dict[str, A
                         raise RuntimeError(
                             f"CallVCDATA: wave data uncompressed length mismatch for var {i}"
                         )
+                    entry["bin"] = dec_data.hex()
                 except Exception as e:
                     entry["lz4_error"] = f"decompression error: {str(e)}"
                 else:


### PR DESCRIPTION
According to [spec](https://blog.timhutt.co.uk/fst_spec/#_waves_table), wave_table with uncompressed length 0 means data is uncompressed.    
The parser always try to decompress it will create lz4_error terms in output. This MR fixes the issue.
